### PR TITLE
Fix coverage excludes default

### DIFF
--- a/jtec-agent/src/main/java/edu/tum/sse/jtec/agent/AgentOptions.java
+++ b/jtec-agent/src/main/java/edu/tum/sse/jtec/agent/AgentOptions.java
@@ -28,7 +28,7 @@ public class AgentOptions {
     public static final String COVERAGE_EXCLUDES = "cov.excludes";
     public static final CoverageLevel DEFAULT_COVERAGE_LEVEL = CoverageLevel.CLASS;
     public static final String DEFAULT_COVERAGE_INCLUDES = ".*";
-    public static final String DEFAULT_COVERAGE_EXCLUDES = "(sun|java|jdk|com.sun|edu.tum.sse.jtec|net.bytebuddy|org.apache.maven|org.junit).*";
+    public static final String DEFAULT_COVERAGE_EXCLUDES = "(sun|java|com.sun|edu.tum.sse.jtec|net.bytebuddy|org.apache.maven|org.junit).*";
 
     // Pre-test hook.
     public static final String PRE_TEST_COMMAND = "init.cmd";


### PR DESCRIPTION
`jdk` in the `cov.excludes` string breaks JTeC on Windows 

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[ERROR] Der Befehl "jdk" ist entweder falsch geschrieben oder
[ERROR] konnte nicht gefunden werden.
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```