### PR TITLE
Fail report aggregate Mojo if only empty reports found

### DIFF
--- a/jtec-core/dependency-reduced-pom.xml
+++ b/jtec-core/dependency-reduced-pom.xml
@@ -84,10 +84,10 @@
     </dependency>
   </dependencies>
   <properties>
+    <mockito.version>4.5.1</mockito.version>
+    <junit-platform.version>1.7.0</junit-platform.version>
     <bytebuddy.version>1.12.10</bytebuddy.version>
     <junit4.version>4.13.1</junit4.version>
-    <junit-platform.version>1.7.0</junit-platform.version>
     <junit5.version>5.7.0</junit5.version>
-    <mockito.version>4.5.1</mockito.version>
   </properties>
 </project>

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/AbstractJTeCReportMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/AbstractJTeCReportMojo.java
@@ -3,6 +3,7 @@ package edu.tum.sse.jtec.mojo;
 import edu.tum.sse.jtec.reporting.TestReport;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
@@ -14,10 +15,15 @@ public abstract class AbstractJTeCReportMojo extends AbstractJTeCMojo {
 
     final static String TEST_REPORT_FILENAME = "test-report.json";
 
-    void storeTestReport(TestReport testReport) throws IOException {
-        final String jsonTestReport = toJson(testReport);
+    boolean storeTestReport(TestReport testReport) throws IOException {
         Path jsonFile = outputDirectory.toPath().resolve(TEST_REPORT_FILENAME);
-        createFileAndEnclosingDir(jsonFile);
-        writeToFile(jsonFile, jsonTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);
+        Files.deleteIfExists(jsonFile);
+        if (testReport.getTestSuites().size() > 0) {
+            final String jsonTestReport = toJson(testReport);
+            createFileAndEnclosingDir(jsonFile);
+            writeToFile(jsonFile, jsonTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);
+            return true;
+        }
+        return false;
     }
 }

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCReportAggregateMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCReportAggregateMojo.java
@@ -9,7 +9,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -45,13 +44,15 @@ public class JTeCReportAggregateMojo extends AbstractJTeCReportMojo {
                         .collect(Collectors.toList());
                 ReportGenerator reportGenerator = new ReportGenerator(outputDirectory.toPath(), true);
                 TestReport testReport = reportGenerator.aggregateReports(project.getName(), testReports);
-                storeTestReport(testReport);
-                log("Writing aggregated JTeC report to " + outputDirectory.toPath());
                 session.setProjects(Collections.emptyList());
+                if (!storeTestReport(testReport)) {
+                    throw new MojoFailureException("Failed to create aggregated JTeC test report, found only empty reports.");
+                }
             }
         } catch (final Exception exception) {
             getLog().error("Failed to aggregate JTeC reports in project " + project.getName());
             exception.printStackTrace();
+            throw new MojoFailureException(exception.getMessage());
         }
     }
 


### PR DESCRIPTION
The `report-aggregate` mojo previously did not show any difference in exit code if it successfully aggregated jtec reports or it did not find any valid reports. This PR uses the regular Mojo exception mechanism to signify that something went wrong.