### PR TITLE
Auto-detect includes from Maven output directory

### DIFF
--- a/jtec-agent/src/main/java/edu/tum/sse/jtec/agent/AgentOptions.java
+++ b/jtec-agent/src/main/java/edu/tum/sse/jtec/agent/AgentOptions.java
@@ -83,10 +83,6 @@ public class AgentOptions {
     private String preTestCommand;
     private Path outputPath;
 
-    public void setFileIncludes(String fileIncludes) {
-        this.fileIncludes = fileIncludes;
-    }
-
     private String fileIncludes;
     private String fileExcludes;
 
@@ -220,6 +216,10 @@ public class AgentOptions {
 
     public String getCoverageIncludes() {
         return coverageIncludes;
+    }
+
+    public void setCoverageIncludes(String fileIncludes) {
+        this.coverageIncludes = fileIncludes;
     }
 
     public String getCoverageExcludes() {

--- a/jtec-agent/src/main/java/edu/tum/sse/jtec/agent/AgentOptions.java
+++ b/jtec-agent/src/main/java/edu/tum/sse/jtec/agent/AgentOptions.java
@@ -82,6 +82,11 @@ public class AgentOptions {
     private String coverageExcludes;
     private String preTestCommand;
     private Path outputPath;
+
+    public void setFileIncludes(String fileIncludes) {
+        this.fileIncludes = fileIncludes;
+    }
+
     private String fileIncludes;
     private String fileExcludes;
 

--- a/jtec-core/dependency-reduced-pom.xml
+++ b/jtec-core/dependency-reduced-pom.xml
@@ -84,10 +84,10 @@
     </dependency>
   </dependencies>
   <properties>
-    <mockito.version>4.5.1</mockito.version>
-    <junit-platform.version>1.7.0</junit-platform.version>
     <bytebuddy.version>1.12.10</bytebuddy.version>
     <junit4.version>4.13.1</junit4.version>
+    <junit-platform.version>1.7.0</junit-platform.version>
     <junit5.version>5.7.0</junit5.version>
+    <mockito.version>4.5.1</mockito.version>
   </properties>
 </project>

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
@@ -97,7 +97,7 @@ public class JTeCMojo extends AbstractJTeCMojo {
             }
         });
         if (paths.stream().anyMatch(currentPath -> !Files.isDirectory(currentPath))) {
-            return path.toString().substring(remainingPath.length());
+            return path.toString().substring(remainingPath.length() + 1);
         }
         StringBuilder result = new StringBuilder();
         for (Path currentPath : paths) {

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
@@ -8,13 +8,16 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 import static edu.tum.sse.jtec.util.IOUtils.locateJar;
 
@@ -25,57 +28,58 @@ import static edu.tum.sse.jtec.util.IOUtils.locateJar;
  * <a href="https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#debugForkedProcess">Surefire</a> or
  * <a href="https://maven.apache.org/surefire/maven-failsafe-plugin/integration-test-mojo.html#debugForkedProcess">Failsafe</a> debug option.
  */
-@Mojo(name = "jtec", defaultPhase = LifecyclePhase.INITIALIZE, threadSafe = true)
+@Mojo(name = "jtec", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES, threadSafe = true)
 public class JTeCMojo extends AbstractJTeCMojo {
 
+    public static final char PACKAGE_SEPARATOR = '.';
     private static final String SUREFIRE_DEBUG_OPTION = "maven.surefire.debug";
     private static final String FAILSAFE_DEBUG_OPTION = "maven.failsafe.debug";
     private static final String META_INF = "META-INF";
-
-
     /**
      * JTeC options passed to the JTeC agent.
      */
     @Parameter(property = "jtec.opts", readonly = true)
     String agentOpts;
 
-    @Parameter(property = "jtec.autoinclude", readonly = true)
+    /**
+     * JTeC option to generate include patterns automatically.
+     * Only works reliably if the test and source classes are in the same module.
+     */
+    @Parameter(property = "jtec.autoinclude", readonly = true, defaultValue = "false")
     Boolean autoinclude;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
             log("Executing JTeC Maven plugin with agentOpts=" + agentOpts + " for project " + project.getName());
-            String preparedAgentOpts = prepareAgentOpts();
-            Path agentJar = locateJar(JTeCAgent.class);
-            Properties properties = project.getProperties();
-            for (String property : new String[]{SUREFIRE_DEBUG_OPTION, FAILSAFE_DEBUG_OPTION}) {
-                String oldValue = properties.getProperty(property);
-                String newValue = String.format("%s-javaagent:%s=%s", (oldValue == null ? "" : oldValue + " "), agentJar.toAbsolutePath(), preparedAgentOpts);
+            final String preparedAgentOpts = prepareAgentOpts();
+            final Path agentJar = locateJar(JTeCAgent.class);
+            final Properties properties = project.getProperties();
+            for (final String property : new String[]{SUREFIRE_DEBUG_OPTION, FAILSAFE_DEBUG_OPTION}) {
+                final String oldValue = properties.getProperty(property);
+                final String newValue = String.format("%s-javaagent:%s=%s", (oldValue == null ? "" : oldValue + " "), agentJar.toAbsolutePath(), preparedAgentOpts);
                 properties.setProperty(property, newValue);
                 log(String.format("Changing Maven property %s to %s.", property, newValue));
             }
-        } catch (Exception exception) {
+        } catch (final Exception exception) {
             getLog().error("Failed to find JTeC agent JAR, skipping instrumentation.");
             exception.printStackTrace();
         }
     }
 
     private String prepareAgentOpts() {
-        AgentOptions agentOptions;
+        final AgentOptions agentOptions;
         if (agentOpts == null) {
             agentOptions = AgentOptions.DEFAULT_OPTIONS;
         } else {
             agentOptions = AgentOptions.fromString(agentOpts);
         }
         agentOptions.setOutputPath(outputDirectory.toPath());
-        if (autoinclude) {
+        if (autoinclude && Files.exists(Paths.get(project.getBuild().getOutputDirectory()))) {
             String autoincludePatterns = "";
             try {
-                String sourceDirectory = project.getBuild().getSourceDirectory();
-                autoincludePatterns = findAutoincludePatterns(Paths.get(sourceDirectory), sourceDirectory);
-                autoincludePatterns = "(" + autoincludePatterns + ")" + ".*";
-            } catch (IOException e) {
+                autoincludePatterns = buildAutoIncludePattern();
+            } catch (final IOException e) {
                 getLog().warn("No Source dir found!", e);
             }
             if (!autoincludePatterns.isEmpty()) {
@@ -88,24 +92,37 @@ public class JTeCMojo extends AbstractJTeCMojo {
         return agentString;
     }
 
-    private String findAutoincludePatterns(Path path, String remainingPath) throws IOException {
-        List<Path> paths = new ArrayList<>();
-        log("Searching for autoinclude Patterns in " + path);
-        Files.list(path).forEach(filePath -> {
-            if (!filePath.getFileName().endsWith(META_INF)) {
-                paths.add(filePath);
-            }
-        });
-        if (paths.stream().anyMatch(currentPath -> !Files.isDirectory(currentPath))) {
-            return path.toString().substring(remainingPath.length() + 1);
-        }
-        StringBuilder result = new StringBuilder();
-        for (Path currentPath : paths) {
-            result.append(findAutoincludePatterns(currentPath, remainingPath));
-            result.append(';');
+    private String buildAutoIncludePattern() throws IOException {
+        final Set<String> includePaths = new HashSet<>();
+        final String classDirectory = project.getBuild().getOutputDirectory();
+        findAutoincludePatterns(Paths.get(classDirectory), classDirectory, includePaths);
+
+        final String testClassDir = project.getBuild().getTestOutputDirectory();
+        findAutoincludePatterns(Paths.get(testClassDir), testClassDir, includePaths);
+
+        final StringBuilder result = new StringBuilder();
+        for (final String path : includePaths) {
+            result.append(path);
+            result.append(AgentOptions.PIPE_REPLACEMENT);
         }
         result.deleteCharAt(result.length() - 1);
-        return result.toString().replace('/', '.');
+        final String includePackages = result.toString().replace(File.separatorChar, PACKAGE_SEPARATOR);
+        return "(" + includePackages + ")" + ".*";
+    }
+
+    private void findAutoincludePatterns(final Path path, final String classDir, final Set<String> includePaths) throws IOException {
+        final List<Path> paths = new ArrayList<>();
+        log("Searching for autoinclude Patterns in " + path);
+        Files.list(path).forEach(paths::add);
+        if (paths.stream().anyMatch(currentPath -> currentPath.toString().endsWith(".class"))) {
+            includePaths.add(path.toString().substring(classDir.length() + 1));
+            return;
+        }
+        for (final Path currentPath : paths) {
+            if (Files.isDirectory(currentPath)) {
+                findAutoincludePatterns(currentPath, classDir, includePaths);
+            }
+        }
     }
 
 }

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
@@ -96,7 +96,7 @@ public class JTeCMojo extends AbstractJTeCMojo {
             }
         });
         if (paths.stream().anyMatch(currentPath -> !Files.isDirectory(currentPath))) {
-            return path.toString();
+            return path.toString().substring(1);
         }
         StringBuilder result = new StringBuilder();
         for (Path currentPath : paths) {

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
@@ -8,7 +8,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -71,8 +70,16 @@ public class JTeCMojo extends AbstractJTeCMojo {
         }
         agentOptions.setOutputPath(outputDirectory.toPath());
         if (autoinclude) {
-            String autoincludePatterns = findAutoincludePatterns(project.getBuild().getOutputDirectory());
-            agentOptions.setFileIncludes(autoincludePatterns);
+            String autoincludePatterns = "";
+            try {
+                autoincludePatterns = findAutoincludePatterns(project.getBuild().getOutputDirectory());
+            } catch (IOException e) {
+                log("No Class dir found!");
+                log(e.getMessage());
+            }
+            if (!autoincludePatterns.isEmpty()) {
+                agentOptions.setFileIncludes(autoincludePatterns);
+            }
         }
         String agentString = agentOptions.toAgentString();
         // Fix for Win32 where a pipe character in a command line sometimes breaks process execution.
@@ -82,6 +89,7 @@ public class JTeCMojo extends AbstractJTeCMojo {
 
     private String findAutoincludePatterns(String path) throws IOException {
         List<Path> paths = new ArrayList<>();
+        log("Searching for autoinclude Patterns!");
         Files.list(Paths.get(path)).forEach(filePath -> {
             if (!filePath.getFileName().toString().equals(META_INF)) {
                 paths.add(filePath);

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
@@ -77,6 +77,7 @@ public class JTeCMojo extends AbstractJTeCMojo {
             } catch (IOException e) {
                 log("No Source dir found!");
                 log(e.getMessage());
+                e.printStackTrace();
             }
             if (!autoincludePatterns.isEmpty()) {
                 agentOptions.setFileIncludes(autoincludePatterns);
@@ -90,13 +91,13 @@ public class JTeCMojo extends AbstractJTeCMojo {
 
     private String findAutoincludePatterns(Path path) throws IOException {
         List<Path> paths = new ArrayList<>();
-        log("Searching for autoinclude Patterns!");
+        log("Searching for autoinclude Patterns in " + path);
         Files.list(path).forEach(filePath -> {
-            if (!filePath.getFileName().toString().equals(META_INF)) {
+            if (!filePath.getFileName().endsWith(META_INF)) {
                 paths.add(filePath);
             }
         });
-        if (paths.stream().anyMatch(currentPath -> currentPath.endsWith(".java"))) {
+        if (paths.stream().anyMatch(currentPath -> !Files.isDirectory(currentPath))) {
             return path.toString();
         }
         StringBuilder result = new StringBuilder();

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
@@ -25,7 +25,7 @@ import static edu.tum.sse.jtec.util.IOUtils.locateJar;
  * <a href="https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#debugForkedProcess">Surefire</a> or
  * <a href="https://maven.apache.org/surefire/maven-failsafe-plugin/integration-test-mojo.html#debugForkedProcess">Failsafe</a> debug option.
  */
-@Mojo(name = "jtec", defaultPhase = LifecyclePhase.INITIALIZE, threadSafe = true)
+@Mojo(name = "jtec", defaultPhase = LifecyclePhase.PROCESS_TEST_RESOURCES, threadSafe = true)
 public class JTeCMojo extends AbstractJTeCMojo {
 
     private static final String SUREFIRE_DEBUG_OPTION = "maven.surefire.debug";

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
@@ -42,8 +42,6 @@ public class JTeCMojo extends AbstractJTeCMojo {
     @Parameter(property = "jtec.autoinclude", readonly = true)
     Boolean autoinclude;
 
-    String sourceDirectory = project.getBuild().getSourceDirectory();
-
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
@@ -74,7 +72,8 @@ public class JTeCMojo extends AbstractJTeCMojo {
         if (autoinclude) {
             String autoincludePatterns = "";
             try {
-                autoincludePatterns = findAutoincludePatterns(Paths.get(sourceDirectory));
+                String sourceDirectory = project.getBuild().getSourceDirectory();
+                autoincludePatterns = findAutoincludePatterns(Paths.get(sourceDirectory), sourceDirectory);
                 autoincludePatterns = "(" + autoincludePatterns + ")" + ".*";
             } catch (IOException e) {
                 getLog().warn("No Source dir found!", e);
@@ -89,7 +88,7 @@ public class JTeCMojo extends AbstractJTeCMojo {
         return agentString;
     }
 
-    private String findAutoincludePatterns(Path path) throws IOException {
+    private String findAutoincludePatterns(Path path, String remainingPath) throws IOException {
         List<Path> paths = new ArrayList<>();
         log("Searching for autoinclude Patterns in " + path);
         Files.list(path).forEach(filePath -> {
@@ -98,11 +97,11 @@ public class JTeCMojo extends AbstractJTeCMojo {
             }
         });
         if (paths.stream().anyMatch(currentPath -> !Files.isDirectory(currentPath))) {
-            return path.toString().substring(sourceDirectory.length());
+            return path.toString().substring(remainingPath.length());
         }
         StringBuilder result = new StringBuilder();
         for (Path currentPath : paths) {
-            result.append(findAutoincludePatterns(currentPath));
+            result.append(findAutoincludePatterns(currentPath, remainingPath));
             result.append(';');
         }
         result.deleteCharAt(result.length() - 1);

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
@@ -34,7 +34,7 @@ public class JTeCMojo extends AbstractJTeCMojo {
     public static final char PACKAGE_SEPARATOR = '.';
     private static final String SUREFIRE_DEBUG_OPTION = "maven.surefire.debug";
     private static final String FAILSAFE_DEBUG_OPTION = "maven.failsafe.debug";
-    private static final String META_INF = "META-INF";
+
     /**
      * JTeC options passed to the JTeC agent.
      */

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
@@ -75,12 +75,10 @@ public class JTeCMojo extends AbstractJTeCMojo {
                 autoincludePatterns = findAutoincludePatterns(Paths.get(project.getBuild().getSourceDirectory()));
                 autoincludePatterns = "(" + autoincludePatterns + ")" + ".*";
             } catch (IOException e) {
-                log("No Source dir found!");
-                log(e.getMessage());
-                e.printStackTrace();
+                getLog().warn("No Source dir found!", e);
             }
             if (!autoincludePatterns.isEmpty()) {
-                agentOptions.setFileIncludes(autoincludePatterns);
+                agentOptions.setCoverageIncludes(autoincludePatterns);
             }
         }
         String agentString = agentOptions.toAgentString();

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
@@ -104,7 +104,7 @@ public class JTeCMojo extends AbstractJTeCMojo {
             result.append(';');
         }
         result.deleteCharAt(result.length() - 1);
-        return result.toString();
+        return result.toString().replace('/', '.');
     }
 
 }

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCMojo.java
@@ -42,6 +42,8 @@ public class JTeCMojo extends AbstractJTeCMojo {
     @Parameter(property = "jtec.autoinclude", readonly = true)
     Boolean autoinclude;
 
+    String sourceDirectory = project.getBuild().getSourceDirectory();
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
@@ -72,7 +74,7 @@ public class JTeCMojo extends AbstractJTeCMojo {
         if (autoinclude) {
             String autoincludePatterns = "";
             try {
-                autoincludePatterns = findAutoincludePatterns(Paths.get(project.getBuild().getSourceDirectory()));
+                autoincludePatterns = findAutoincludePatterns(Paths.get(sourceDirectory));
                 autoincludePatterns = "(" + autoincludePatterns + ")" + ".*";
             } catch (IOException e) {
                 getLog().warn("No Source dir found!", e);
@@ -96,7 +98,7 @@ public class JTeCMojo extends AbstractJTeCMojo {
             }
         });
         if (paths.stream().anyMatch(currentPath -> !Files.isDirectory(currentPath))) {
-            return path.toString().substring(1);
+            return path.toString().substring(sourceDirectory.length());
         }
         StringBuilder result = new StringBuilder();
         for (Path currentPath : paths) {


### PR DESCRIPTION
Adds a `-Djtec.autoinclude` option which automatically infers a regular expression to include only packages that are part of the Maven project. 