### PR TITLE
Add LCOV support

### DIFF
--- a/jtec-agent/pom.xml
+++ b/jtec-agent/pom.xml
@@ -79,6 +79,10 @@
                                     <shadedPattern>com.google.shaded</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.github</pattern>
+                                    <shadedPattern>com.github.shaded</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>junit</pattern>
                                     <shadedPattern>junit.shaded</shadedPattern>
                                 </relocation>

--- a/jtec-core/pom.xml
+++ b/jtec-core/pom.xml
@@ -40,11 +40,6 @@
             <version>2.9.0</version>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
             <version>3.24.8</version>

--- a/jtec-core/pom.xml
+++ b/jtec-core/pom.xml
@@ -40,6 +40,16 @@
             <version>2.9.0</version>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>3.24.8</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
             <version>${junit-platform.version}</version>

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReport.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReport.java
@@ -1,6 +1,5 @@
 package edu.tum.sse.jtec.reporting;
 
-import java.nio.file.Path;
 import java.util.List;
 
 public class LCOVReport {
@@ -8,6 +7,38 @@ public class LCOVReport {
 
     public LCOVReport(List<LCOVSection> lcovSections) {
         this.lcovSections = lcovSections;
+    }
+
+    public List<LCOVSection> getLcovSections() {
+        return lcovSections;
+    }
+
+    public void setLcovSections(List<LCOVSection> lcovSections) {
+        this.lcovSections = lcovSections;
+    }
+
+    /**
+     * Get the LCOV section for the given source file.
+     * @param sourceFilePath The path to the source file
+     * @return The LCOV section if it exists, else null
+     */
+    public LCOVSection getLcovSection(String sourceFilePath) {
+        return lcovSections.stream()
+                .filter(l -> l.getSourceFilePath().equals(sourceFilePath))
+                .findFirst().orElse(null);
+    }
+
+    /**
+     * Add new LCOV section if none already exists for the same source file.
+     * @param lcovSection The LCOV section to be added
+     * @return true if new section was added
+     */
+    public boolean addLcovSection(LCOVSection lcovSection) {
+        if (getLcovSection(lcovSection.getSourceFilePath()) == null) {
+            lcovSections.add(lcovSection);
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -20,13 +51,5 @@ public class LCOVReport {
         for (LCOVSection section : lcovSections)
             lcovString.append(section.toString());
         return lcovString.toString();
-    }
-
-    public List<LCOVSection> getLcovSections() {
-        return lcovSections;
-    }
-
-    public void setLcovSections(List<LCOVSection> lcovSections) {
-        this.lcovSections = lcovSections;
     }
 }

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReport.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReport.java
@@ -29,19 +29,6 @@ public class LCOVReport {
     }
 
     /**
-     * Add new LCOV section if none already exists for the same source file.
-     * @param lcovSection The LCOV section to be added
-     * @return true if new section was added
-     */
-    public boolean addLcovSection(LCOVSection lcovSection) {
-        if (getLcovSection(lcovSection.getSourceFilePath()) == null) {
-            lcovSections.add(lcovSection);
-            return true;
-        }
-        return false;
-    }
-
-    /**
      * Convert the LCOV report into a tracefile using the LCOV format.
      * @return The LCOV tracefile as a String
      */

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReport.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReport.java
@@ -1,0 +1,32 @@
+package edu.tum.sse.jtec.reporting;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public class LCOVReport {
+    private List<LCOVSection> lcovSections;
+
+    public LCOVReport(List<LCOVSection> lcovSections) {
+        this.lcovSections = lcovSections;
+    }
+
+    /**
+     * Convert the LCOV report into a tracefile using the LCOV format.
+     * @return The LCOV tracefile as a String
+     */
+    @Override
+    public String toString() {
+        StringBuilder lcovString = new StringBuilder();
+        for (LCOVSection section : lcovSections)
+            lcovString.append(section.toString());
+        return lcovString.toString();
+    }
+
+    public List<LCOVSection> getLcovSections() {
+        return lcovSections;
+    }
+
+    public void setLcovSections(List<LCOVSection> lcovSections) {
+        this.lcovSections = lcovSections;
+    }
+}

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReport.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReport.java
@@ -1,6 +1,7 @@
 package edu.tum.sse.jtec.reporting;
 
 import java.util.List;
+import java.util.Optional;
 
 public class LCOVReport {
     private List<LCOVSection> lcovSections;
@@ -22,10 +23,10 @@ public class LCOVReport {
      * @param sourceFilePath The path to the source file
      * @return The LCOV section if it exists, else null
      */
-    public LCOVSection getLcovSection(String sourceFilePath) {
+    public Optional<LCOVSection> getLcovSection(String sourceFilePath) {
         return lcovSections.stream()
                 .filter(l -> l.getSourceFilePath().equals(sourceFilePath))
-                .findFirst().orElse(null);
+                .findFirst();
     }
 
     /**

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReportParser.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReportParser.java
@@ -3,21 +3,19 @@ package edu.tum.sse.jtec.reporting;
 import com.github.javaparser.Range;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import edu.tum.sse.jtec.util.IOUtils;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Parse a {@link TestReport} into an {@link LCOVReport}.
@@ -62,32 +60,51 @@ public class LCOVReportParser {
 
         for (TestSuite testSuite : testReport.getTestSuites()) {
             for (String entity : testSuite.getCoveredEntities()) {
+                // Get package, class and method from entity; replace constructor name
                 final String[] entityComponents = getEntityComponents(entity);
                 if (entityComponents == null)
                     continue;
-                final String packageName = entityComponents[0], className = entityComponents[1], methodName = entityComponents[2];
+                final String packageName = entityComponents[0];
+                final String className = entityComponents[1];
+                String tempMethodName = entityComponents[2];
+                if (tempMethodName != null && tempMethodName.equals("<init>"))
+                    tempMethodName = className;
+                final String methodName = tempMethodName;
                 final String fullyQualifiedClassName = packageName + "." + className;
 
+                // Find source file containing the class
+                // TODO: Build className to sourceFile mapping, query here
                 final Path sourceFile = getJavaSourceFile(fullyQualifiedClassName);
                 if (sourceFile == null)
                     continue;
                 final String sourceFilePath = sourceFile.toString();
 
+                // Get LCOV section describing the source file
+                LCOVSection lcovSection = lcovReport.getLcovSection(sourceFilePath);
+                if (lcovSection == null)
+                    continue;
+
+                // Get class declaration from source file
                 final String sourceCode = IOUtils.readFromFile(sourceFile);
                 final CompilationUnit compilationUnit = StaticJavaParser.parse(sourceCode);
                 final ClassOrInterfaceDeclaration classDeclaration = compilationUnit.getClassByName(className).orElse(null);
                 if (classDeclaration == null)
                     continue;
 
-                LCOVSection lcovSection = lcovReport.getLcovSection(sourceFilePath);
-                if (lcovSection == null)
-                    continue;
-                final List<MethodDeclaration> methodDeclarations = (methodName != null) ? classDeclaration.getMethodsByName(methodName) : classDeclaration.getMethods();
-                for (MethodDeclaration methodDeclaration : methodDeclarations) {
-                    final Range range = methodDeclaration.getRange().orElse(null);
+                // Get either all callables (methods, constructors), or the method `methodName`.
+                List<CallableDeclaration> callableDeclarations = classDeclaration
+                        .findAll(CallableDeclaration.class).stream()
+                        .filter((methodName != null)
+                                ? callableDeclaration -> callableDeclaration.getNameAsString().equals(methodName)
+                                : callableDeclaration -> true)
+                        .collect(Collectors.toList());
+
+                // Add method and line coverage information for callables
+                for (CallableDeclaration callableDeclaration : callableDeclarations) {
+                    final Range range = callableDeclaration.getRange().orElse(null);
                     if (range == null)
                         continue;
-                    lcovSection.addMethodHit(1, methodDeclaration.getNameAsString());
+                    lcovSection.addMethodHit(1, callableDeclaration.getNameAsString());
                     for (int line = range.begin.line; line <= range.end.line; line++)
                         lcovSection.addLineHit(line, 1);
                 }
@@ -98,7 +115,7 @@ public class LCOVReportParser {
 
     /**
      * For each method in each source file, create an LCOV section with hit count 0 for all lines.
-     * @return The list of initializd LCOV sections
+     * @return The list of initialized LCOV sections
      */
     private List<LCOVSection> getInitializedLcovSections() throws IOException {
         List<LCOVSection> lcovSections = new ArrayList<>();
@@ -106,15 +123,17 @@ public class LCOVReportParser {
             final LCOVSection lcovSection = new LCOVSection("", file.getAbsolutePath());
             final String sourceCode = IOUtils.readFromFile(file.toPath());
             final CompilationUnit compilationUnit = StaticJavaParser.parse(sourceCode);
-            List<MethodDeclaration> methodDeclarations = compilationUnit.findAll(MethodDeclaration.class);
-            for (MethodDeclaration methodDeclaration : methodDeclarations) {
-                final Range range = methodDeclaration.getRange().orElse(null);
-                if (range == null)
-                    continue;
-                lcovSection.addMethod(range.begin.line, methodDeclaration.getNameAsString());
-                for (int line = range.begin.line; line <= range.end.line; line++)
-                    lcovSection.addLineHit(line, 0);
-            }
+
+            compilationUnit.findAll(CallableDeclaration.class)
+                    .forEach(callableDeclaration -> {
+                        final Range range = callableDeclaration.getRange().orElse(null);
+                        if (range == null)
+                            return;
+                        lcovSection.addMethod(range.begin.line, callableDeclaration.getNameAsString());
+                        for (int line = range.begin.line; line <= range.end.line; line++)
+                            lcovSection.addLineHit(line, 0);
+                    }
+            );
             lcovSections.add(lcovSection);
         }
         return lcovSections;
@@ -133,8 +152,8 @@ public class LCOVReportParser {
 
     /**
      * Extract the package name, class name, and method name from an entity string.
-     * If no method name is present, use null.
-     * @return An array [package, class, method]
+     * If no method name is present, use null for the method.
+     * @return An array [package, class, method], or null if no match is found
      */
     public static String[] getEntityComponents(String entity) {
         Matcher matcher = entityRegex.matcher(entity);

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReportParser.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReportParser.java
@@ -1,0 +1,65 @@
+package edu.tum.sse.jtec.reporting;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+
+/**
+ * Parse a {@link TestReport} into an {@link LCOVReport}.
+ */
+public class LCOVReportParser {
+    /**
+     * The base directory of the test report's project
+     */
+    private File baseDir;
+
+    /**
+     * Extensions of project files to consider in LCOV report
+     */
+    private final String[] FILE_EXTENSIONS = {"java"};
+
+    /**
+     * Project files to add to LCOV report
+     */
+    private Collection<File> sourceFiles;
+
+
+    public LCOVReportParser(File baseDir) {
+        setBaseDir(baseDir);
+    }
+
+    public File getBaseDir() {
+        return baseDir;
+    }
+
+    public void setBaseDir(File baseDir) {
+        this.baseDir = baseDir;
+        this.sourceFiles = FileUtils.listFiles(baseDir, FILE_EXTENSIONS, true);
+    }
+
+    public LCOVReport parse(TestReport testReport) {
+        List<LCOVSection> lcovSections = new ArrayList<>();
+
+        for (TestSuite testSuite : testReport.getTestSuites()) {
+            final Set<String> coveredEntities = testSuite.getCoveredEntities();
+            for (String entity : coveredEntities) {
+
+            }
+        }
+
+        return new LCOVReport(lcovSections);
+    }
+
+    /**
+     * Get the Java source file corresponding to a class
+     * @param className The fully qualified class name
+     * @return The source file if it exists, else null
+     */
+    private Path getJavaSourceFile(String className) {
+        final String relativeFilePath = className.replace('.','/') + ".java";
+        final Optional<Path> sourceFile = sourceFiles.stream().map(File::toPath).filter(p -> p.endsWith(relativeFilePath)).findFirst();
+        return sourceFile.orElse(null);
+    }
+}

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReportParser.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReportParser.java
@@ -59,7 +59,7 @@ public class LCOVReportParser {
                 .filter(Files::isRegularFile)
                 .filter(path -> path.toString().endsWith(SOURCE_FILE_EXTENSION))
                 .collect(Collectors.toList());
-        this.classToSourceFile = getClassToSourceFilePath();
+        this.classToSourceFile = getClassToSourceFileMap();
     }
 
     public LCOVReport parse(TestReport testReport) throws IOException {
@@ -125,7 +125,7 @@ public class LCOVReportParser {
      * @return The Map from class name to source file path
      * @throws IOException
      */
-    private Map<String, Path> getClassToSourceFilePath() throws IOException {
+    private Map<String, Path> getClassToSourceFileMap() throws IOException {
         Map<String, Path> classToSourceFile = new HashMap<>();
         for (Path sourceFile : sourceFiles) {
             final String sourceCode = IOUtils.readFromFile(sourceFile);

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReportParser.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReportParser.java
@@ -1,10 +1,22 @@
 package edu.tum.sse.jtec.reporting;
 
+import com.github.javaparser.Range;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import edu.tum.sse.jtec.util.IOUtils;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Parse a {@link TestReport} into an {@link LCOVReport}.
@@ -25,6 +37,10 @@ public class LCOVReportParser {
      */
     private Collection<File> sourceFiles;
 
+    /**
+     * Regex for parsing entities into their components (package.name.Class#method)
+     */
+    final static Pattern entityRegex = Pattern.compile("^(\\S*)\\.([^#]*)(?:#(\\S*))?$");
 
     public LCOVReportParser(File baseDir) {
         setBaseDir(baseDir);
@@ -39,17 +55,85 @@ public class LCOVReportParser {
         this.sourceFiles = FileUtils.listFiles(baseDir, FILE_EXTENSIONS, true);
     }
 
-    public LCOVReport parse(TestReport testReport) {
+    public LCOVReport parse(TestReport testReport) throws IOException {
         List<LCOVSection> lcovSections = new ArrayList<>();
 
         for (TestSuite testSuite : testReport.getTestSuites()) {
             final Set<String> coveredEntities = testSuite.getCoveredEntities();
             for (String entity : coveredEntities) {
+                final String[] entityComponents = getEntityComponents(entity);
+                if (entityComponents == null)
+                    continue;
+                final String packageName = entityComponents[0], className = entityComponents[1], methodName = entityComponents[2];
+                final String fullyQualifiedClassName = packageName + "." + className;
+                final Path sourceFile = getJavaSourceFile(fullyQualifiedClassName);
 
+                if (sourceFile == null)
+                    continue;
+
+                final LCOVSection lcovSection = new LCOVSection(testSuite.getTestId(), sourceFile.toString());
+                final String sourceCode = IOUtils.readFromFile(sourceFile);
+                final CompilationUnit compilationUnit = StaticJavaParser.parse(sourceCode);
+/*
+                Set<Range> methodRanges = compilationUnit
+                        .findAll(MethodDeclaration.class).stream()
+                        .map(Node::getRange)
+                        .filter(Optional::isPresent).map(Optional::get)
+                        .collect(Collectors.toSet());
+
+                compilationUnit.getClassByName(className).get().getMethodsByName("");
+
+*/
+                final ClassOrInterfaceDeclaration classDeclaration = compilationUnit.getClassByName(className).orElse(null);
+                if (classDeclaration == null)
+                    continue;
+                // TODO: Set default range or ignore entity without range?
+                final Range range = classDeclaration.getRange().orElse(null);
+                if (range == null)
+                    continue;
+                for (int line = range.begin.line; line <= range.end.line; line++)
+                    lcovSection.addLineHit(line, 1);
+
+                lcovSections.add(lcovSection);
             }
         }
 
+        List<LCOVSection> lcovSectionsFromSourceFiles = initLcovSectionsForSourceFiles();
+        lcovSections.addAll(lcovSectionsFromSourceFiles);
         return new LCOVReport(lcovSections);
+    }
+
+    /**
+     * For each class in each source file, create an LCOV section with hit count 0 for all lines.
+     * @return The list of initializd LCOV sections
+     */
+    private List<LCOVSection> initLcovSectionsForSourceFiles() throws IOException {
+        List<LCOVSection> lcovSections = new ArrayList<>();
+        for (File file : sourceFiles) {
+            final LCOVSection lcovSection = new LCOVSection("", file.getAbsolutePath());
+            final String sourceCode = IOUtils.readFromFile(file.toPath());
+            final CompilationUnit compilationUnit = StaticJavaParser.parse(sourceCode);
+            List<ClassOrInterfaceDeclaration> classDeclarations = compilationUnit.findAll(ClassOrInterfaceDeclaration.class);
+            List<MethodDeclaration> methodDeclarations = compilationUnit.findAll(MethodDeclaration.class);
+            for (MethodDeclaration methodDeclaration : methodDeclarations) {
+                final Range range = methodDeclaration.getRange().orElse(null);
+                if (range == null)
+                    continue;
+                for (int line = range.begin.line; line <= range.end.line; line++)
+                    lcovSection.addLineHit(line, 0);
+                lcovSections.add(lcovSection);
+            }
+            /*
+            for (ClassOrInterfaceDeclaration classDeclaration : classDeclarations) {
+                final Range range = classDeclaration.getRange().orElse(null);
+                if (range == null)
+                    continue;
+                for (int line = range.begin.line; line <= range.end.line; line++)
+                    lcovSection.addLineHit(line, 0);
+                lcovSections.add(lcovSection);
+            }*/
+        }
+        return lcovSections;
     }
 
     /**
@@ -61,5 +145,19 @@ public class LCOVReportParser {
         final String relativeFilePath = className.replace('.','/') + ".java";
         final Optional<Path> sourceFile = sourceFiles.stream().map(File::toPath).filter(p -> p.endsWith(relativeFilePath)).findFirst();
         return sourceFile.orElse(null);
+    }
+
+    /**
+     * Extract the package name, class name, and method name from an entity string.
+     * If no method name is present, use null.
+     * @return An array [package, class, method]
+     */
+    public static String[] getEntityComponents(String entity) {
+        Matcher matcher = entityRegex.matcher(entity);
+        if (matcher.matches()) {
+            MatchResult result = matcher.toMatchResult();
+            return new String[] {result.group(1), result.group(2), result.group(3)};
+        }
+        return null;
     }
 }

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReportParser.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVReportParser.java
@@ -97,7 +97,7 @@ public class LCOVReportParser {
     }
 
     /**
-     * For each class in each source file, create an LCOV section with hit count 0 for all lines.
+     * For each method in each source file, create an LCOV section with hit count 0 for all lines.
      * @return The list of initializd LCOV sections
      */
     private List<LCOVSection> getInitializedLcovSections() throws IOException {

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVSection.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVSection.java
@@ -21,13 +21,21 @@ public class LCOVSection {
     private final HashMap<Integer, String> methods = new HashMap<>();
 
     /**
-     * Execution count and names of methods (`FNDA`)
+     * Names and execution counts of methods (`FNDA`)
      */
-    private final HashMap<Integer, String> methodHits = new HashMap<>();
+    private final HashMap<String, Integer> methodHits = new HashMap<>();
 
     public LCOVSection(String testName, String sourceFilePath) {
         this.testName = testName;
         this.sourceFilePath = sourceFilePath;
+    }
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public String getSourceFilePath() {
+        return sourceFilePath;
     }
 
     public void addLineHit(int lineNum, int hitCount) {
@@ -39,7 +47,7 @@ public class LCOVSection {
     }
 
     public void addMethodHit(int hitCount, String methodName) {
-        methodHits.put(hitCount, methodName);
+        methodHits.put(methodName, hitCount);
     }
 
     /**
@@ -84,9 +92,9 @@ public class LCOVSection {
             String methodName = method.getValue();
             lcovString.append("FN:").append(lineNum).append(",").append(methodName).append('\n');
         }
-        for (Map.Entry<Integer, String> methodHit : methodHits.entrySet()) {
-            int hitCount = methodHit.getKey();
-            String methodName = methodHit.getValue();
+        for (Map.Entry<String, Integer> methodHit : methodHits.entrySet()) {
+            String methodName= methodHit.getKey();
+            int hitCount = methodHit.getValue();
             lcovString.append("FNDA:").append(hitCount).append(",").append(methodName).append('\n');
         }
         lcovString.append("FNF:").append(numMethodsFound()).append('\n');

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVSection.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVSection.java
@@ -7,13 +7,18 @@ import java.util.Map;
  * Section describing one source file in an LCOV report.
  */
 public class LCOVSection {
-    private String testName;
-    private String sourceFilePath;
+    private final String testName;
+    private final String sourceFilePath;
 
     /**
      * Line numbers and their execution count ("hits")
      */
     private final HashMap<Integer, Integer> lineHits = new HashMap<>();
+
+    public LCOVSection(String testName, String sourceFilePath) {
+        this.testName = testName;
+        this.sourceFilePath = sourceFilePath;
+    }
 
     public void addLineHit(int lineNum, int hitCount) {
         lineHits.put(lineNum, hitCount);

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVSection.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVSection.java
@@ -11,9 +11,19 @@ public class LCOVSection {
     private final String sourceFilePath;
 
     /**
-     * Line numbers and their execution count ("hits")
+     * Line numbers and their execution count ("hits") -> `DA`
      */
     private final HashMap<Integer, Integer> lineHits = new HashMap<>();
+
+    /**
+     * Line numbers and names of method declarations (`FN`)
+     */
+    private final HashMap<Integer, String> methods = new HashMap<>();
+
+    /**
+     * Execution count and names of methods (`FNDA`)
+     */
+    private final HashMap<Integer, String> methodHits = new HashMap<>();
 
     public LCOVSection(String testName, String sourceFilePath) {
         this.testName = testName;
@@ -24,10 +34,18 @@ public class LCOVSection {
         lineHits.put(lineNum, hitCount);
     }
 
+    public void addMethod(int lineNum, String methodName) {
+        methods.put(lineNum, methodName);
+    }
+
+    public void addMethodHit(int hitCount, String methodName) {
+        methodHits.put(hitCount, methodName);
+    }
+
     /**
-     * @return The number of instrumented lines in this source file (`LF`)
+     * @return The number of lines found in this source file (`LF`)
      */
-    public long numLinesInstrumented() {
+    public long numLinesFound() {
         return lineHits.size();
     }
 
@@ -39,20 +57,46 @@ public class LCOVSection {
     }
 
     /**
-     * Convert the section into LCOV format.
-     * @return The LCOV string
+     * @return The number of methods found in this source file (`FNF`)
+     */
+    public long numMethodsFound() {
+        return methods.size();
+    }
+
+    /**
+     * @return The number of methods executed in this source file (`FNH`)
+     */
+    public long numMethodsHit() {
+        return methodHits.size();
+    }
+
+    /**
+     * Convert this section into LCOV format.
+     * @return The LCOV tracefile as a String
      */
     @Override
     public String toString() {
         StringBuilder lcovString = new StringBuilder();
         lcovString.append("TN:").append(testName).append('\n');
         lcovString.append("SF:").append(sourceFilePath).append('\n');
+        for (Map.Entry<Integer, String> method : methods.entrySet()) {
+            int lineNum = method.getKey();
+            String methodName = method.getValue();
+            lcovString.append("FN:").append(lineNum).append(",").append(methodName).append('\n');
+        }
+        for (Map.Entry<Integer, String> methodHit : methodHits.entrySet()) {
+            int hitCount = methodHit.getKey();
+            String methodName = methodHit.getValue();
+            lcovString.append("FNDA:").append(hitCount).append(",").append(methodName).append('\n');
+        }
+        lcovString.append("FNF:").append(numMethodsFound()).append('\n');
+        lcovString.append("FNH:").append(numMethodsHit()).append('\n');
         for (Map.Entry<Integer, Integer> lineHit : lineHits.entrySet()) {
             int lineNum = lineHit.getKey();
             int hitCount = lineHit.getValue();
             lcovString.append("DA:").append(lineNum).append(",").append(hitCount).append('\n');
         }
-        lcovString.append("LF:").append(numLinesInstrumented()).append('\n');
+        lcovString.append("LF:").append(numLinesFound()).append('\n');
         lcovString.append("LH:").append(numLinesHit()).append('\n');
         lcovString.append("end_of_record\n");
         return lcovString.toString();

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVSection.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVSection.java
@@ -1,0 +1,55 @@
+package edu.tum.sse.jtec.reporting;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Section describing one source file in an LCOV report.
+ */
+public class LCOVSection {
+    private String testName;
+    private String sourceFilePath;
+
+    /**
+     * Line numbers and their execution count ("hits")
+     */
+    private final HashMap<Integer, Integer> lineHits = new HashMap<>();
+
+    public void addLineHit(int lineNum, int hitCount) {
+        lineHits.put(lineNum, hitCount);
+    }
+
+    /**
+     * @return The number of instrumented lines in this source file (`LF`)
+     */
+    public long numLinesInstrumented() {
+        return lineHits.size();
+    }
+
+    /**
+     * @return The number of lines executed at least once in this source file (`LH`)
+     */
+    public long numLinesHit() {
+        return lineHits.entrySet().stream().filter(l -> l.getValue() > 0).count();
+    }
+
+    /**
+     * Convert the section into LCOV format.
+     * @return The LCOV string
+     */
+    @Override
+    public String toString() {
+        StringBuilder lcovString = new StringBuilder();
+        lcovString.append("TN:").append(testName).append('\n');
+        lcovString.append("SF:").append(sourceFilePath).append('\n');
+        for (Map.Entry<Integer, Integer> lineHit : lineHits.entrySet()) {
+            int lineNum = lineHit.getKey();
+            int hitCount = lineHit.getValue();
+            lcovString.append("DA:").append(lineNum).append(",").append(hitCount).append('\n');
+        }
+        lcovString.append("LF:").append(numLinesInstrumented()).append('\n');
+        lcovString.append("LH:").append(numLinesHit()).append('\n');
+        lcovString.append("end_of_record\n");
+        return lcovString.toString();
+    }
+}

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVSection.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/reporting/LCOVSection.java
@@ -13,17 +13,17 @@ public class LCOVSection {
     /**
      * Line numbers and their execution count ("hits") -> `DA`
      */
-    private final HashMap<Integer, Integer> lineHits = new HashMap<>();
+    private final Map<Integer, Integer> lineHits = new HashMap<>();
 
     /**
      * Line numbers and names of method declarations (`FN`)
      */
-    private final HashMap<Integer, String> methods = new HashMap<>();
+    private final Map<Integer, String> methods = new HashMap<>();
 
     /**
      * Names and execution counts of methods (`FNDA`)
      */
-    private final HashMap<String, Integer> methodHits = new HashMap<>();
+    private final Map<String, Integer> methodHits = new HashMap<>();
 
     public LCOVSection(String testName, String sourceFilePath) {
         this.testName = testName;
@@ -106,7 +106,7 @@ public class LCOVSection {
         }
         lcovString.append("LF:").append(numLinesFound()).append('\n');
         lcovString.append("LH:").append(numLinesHit()).append('\n');
-        lcovString.append("end_of_record\n");
+        lcovString.append("end_of_record").append('\n');
         return lcovString.toString();
     }
 }

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/util/LCOVUtils.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/util/LCOVUtils.java
@@ -1,78 +1,23 @@
 package edu.tum.sse.jtec.util;
 
-import com.github.javaparser.Range;
-import com.github.javaparser.StaticJavaParser;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import edu.tum.sse.jtec.reporting.LCOVReport;
 import edu.tum.sse.jtec.reporting.LCOVReportParser;
 import edu.tum.sse.jtec.reporting.TestReport;
-import edu.tum.sse.jtec.reporting.TestSuite;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.file.PathUtils;
-import org.apache.commons.io.filefilter.DirectoryFileFilter;
-import org.apache.commons.io.filefilter.RegexFileFilter;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Stream;
 
 public class LCOVUtils {
-    /*
-    public static String toLcov(TestReport testReport, File baseDir) throws IOException {
-        // TODO: Make non-static, refactor into methods
-        StringBuilder lcovTestReport = new StringBuilder();
-        final String[] fileExtensions = {"java"};
-        final Collection<File> javaSourceFiles = FileUtils.listFiles(baseDir, fileExtensions, true);
-
-        for (TestSuite testSuite : testReport.getTestSuites()) {
-            final Set<String> coveredEntities = testSuite.getCoveredEntities();
-            for (String entity : coveredEntities) {
-                final Path sourceFile = getSourceFile(javaSourceFiles, entity);
-                if (sourceFile == null)
-                    continue;
-
-                // TODO: get covered lines (use entire class/method)
-                final String sourceCode = IOUtils.readFromFile(sourceFile);
-                final String entityName = entity.substring(entity.lastIndexOf('.') + 1);
-                final CompilationUnit compilationUnit = StaticJavaParser.parse(sourceCode);
-
-                final ClassOrInterfaceDeclaration classDeclaration = compilationUnit.getClassByName(entityName).orElse(null);
-                if (classDeclaration == null)
-                    continue;
-                // TODO: Set default range or ignore entity without range?
-                final Range range = classDeclaration.getRange().orElse(Range.range(0,0,0,0));
-
-                final int numLinesFound = range.getLineCount();
-                final int numLinesHit = range.getLineCount();
-
-                // TODO: add class LCOVSection for single source file
-                lcovTestReport.append("TN:").append(testSuite.getTestId()).append('\n');
-                lcovTestReport.append("SF:").append(sourceFile.toAbsolutePath()).append('\n');
-                for (int line = range.begin.line; line <= range.end.line; line++)
-                    lcovTestReport.append("DA:").append(line).append(",1\n");
-                lcovTestReport.append("LF:").append(numLinesFound).append('\n');
-                lcovTestReport.append("LH:").append(numLinesHit).append('\n');
-                lcovTestReport.append("end_of_record\n");
-            }
-        }
-        return lcovTestReport.toString();
-    }
-    */
+    /**
+     * Convert a test report into a tracefile in the LCOV format.
+     * @param testReport The test report to parse
+     * @param baseDir The root directory of the test report's project
+     * @return The LCOV tracefile as a String
+     * @throws IOException
+     */
     public static String toLcov(TestReport testReport, File baseDir) throws IOException {
         LCOVReportParser lcovReportParser = new LCOVReportParser(baseDir);
         LCOVReport lcovReport = lcovReportParser.parse(testReport);
         return lcovReport.toString();
-    }
-
-    private static Path getSourceFile(Collection<File> javaSourceFiles, String className) {
-        final String relativeFilePath = className.replace('.','/') + ".java";
-        final Optional<Path> sourceFile = javaSourceFiles.stream().map(File::toPath).filter(p -> p.endsWith(relativeFilePath)).findFirst();
-        return sourceFile.orElse(null);
     }
 }

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/util/LCOVUtils.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/util/LCOVUtils.java
@@ -5,6 +5,8 @@ import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import edu.tum.sse.jtec.reporting.LCOVReport;
+import edu.tum.sse.jtec.reporting.LCOVReportParser;
 import edu.tum.sse.jtec.reporting.TestReport;
 import edu.tum.sse.jtec.reporting.TestSuite;
 import org.apache.commons.io.FileUtils;
@@ -21,6 +23,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 public class LCOVUtils {
+    /*
     public static String toLcov(TestReport testReport, File baseDir) throws IOException {
         // TODO: Make non-static, refactor into methods
         StringBuilder lcovTestReport = new StringBuilder();
@@ -59,6 +62,12 @@ public class LCOVUtils {
             }
         }
         return lcovTestReport.toString();
+    }
+    */
+    public static String toLcov(TestReport testReport, File baseDir) throws IOException {
+        LCOVReportParser lcovReportParser = new LCOVReportParser(baseDir);
+        LCOVReport lcovReport = lcovReportParser.parse(testReport);
+        return lcovReport.toString();
     }
 
     private static Path getSourceFile(Collection<File> javaSourceFiles, String className) {

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/util/LCOVUtils.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/util/LCOVUtils.java
@@ -6,17 +6,18 @@ import edu.tum.sse.jtec.reporting.TestReport;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 public class LCOVUtils {
     /**
      * Convert a test report into a tracefile in the LCOV format.
      * @param testReport The test report to parse
-     * @param baseDir The root directory of the test report's project
+     * @param baseDirectory The root directory of the test report's project
      * @return The LCOV tracefile as a String
      * @throws IOException
      */
-    public static String toLcov(TestReport testReport, File baseDir) throws IOException {
-        LCOVReportParser lcovReportParser = new LCOVReportParser(baseDir);
+    public static String toLcov(TestReport testReport, Path baseDirectory) throws IOException {
+        LCOVReportParser lcovReportParser = new LCOVReportParser(baseDirectory);
         LCOVReport lcovReport = lcovReportParser.parse(testReport);
         return lcovReport.toString();
     }

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/util/LCOVUtils.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/util/LCOVUtils.java
@@ -1,37 +1,69 @@
 package edu.tum.sse.jtec.util;
 
+import com.github.javaparser.Range;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import edu.tum.sse.jtec.reporting.TestReport;
 import edu.tum.sse.jtec.reporting.TestSuite;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.file.PathUtils;
+import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import org.apache.commons.io.filefilter.RegexFileFilter;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 public class LCOVUtils {
-    public static String toLcov(TestReport testReport)  {
+    public static String toLcov(TestReport testReport, File baseDir) throws IOException {
+        // TODO: Make non-static, refactor into methods
         StringBuilder lcovTestReport = new StringBuilder();
+        final String[] fileExtensions = {"java"};
+        final Collection<File> javaSourceFiles = FileUtils.listFiles(baseDir, fileExtensions, true);
+
         for (TestSuite testSuite : testReport.getTestSuites()) {
             final Set<String> coveredEntities = testSuite.getCoveredEntities();
-            // TODO: TN at the start of every entity's section?
-            lcovTestReport.append("TN:").append(testSuite.getTestId()).append('\n');
-
-            // TODO: filter for entities in project
             for (String entity : coveredEntities) {
-                // TODO: find associated source file
-                String sourceFilePath = getSourceFilePath(entity);
+                final Path sourceFile = getSourceFile(javaSourceFiles, entity);
+                if (sourceFile == null)
+                    continue;
 
                 // TODO: get covered lines (use entire class/method)
+                final String sourceCode = IOUtils.readFromFile(sourceFile);
+                final String entityName = entity.substring(entity.lastIndexOf('.') + 1);
+                final CompilationUnit compilationUnit = StaticJavaParser.parse(sourceCode);
 
-                // TODO: Append section to lcov report
-                lcovTestReport.append("SF:").append(sourceFilePath).append('\n');
-                // TODO: Add covered line data (DA, LF, LH)
+                final ClassOrInterfaceDeclaration classDeclaration = compilationUnit.getClassByName(entityName).orElse(null);
+                if (classDeclaration == null)
+                    continue;
+                // TODO: Set default range or ignore entity without range?
+                final Range range = classDeclaration.getRange().orElse(Range.range(0,0,0,0));
+
+                final int numLinesFound = range.getLineCount();
+                final int numLinesHit = range.getLineCount();
+
+                // TODO: add class LCOVSection for single source file
+                lcovTestReport.append("TN:").append(testSuite.getTestId()).append('\n');
+                lcovTestReport.append("SF:").append(sourceFile.toAbsolutePath()).append('\n');
+                for (int line = range.begin.line; line <= range.end.line; line++)
+                    lcovTestReport.append("DA:").append(line).append(",1\n");
+                lcovTestReport.append("LF:").append(numLinesFound).append('\n');
+                lcovTestReport.append("LH:").append(numLinesHit).append('\n');
                 lcovTestReport.append("end_of_record\n");
             }
         }
         return lcovTestReport.toString();
     }
 
-    private static String getSourceFilePath(String className) {
-        // TODO Retrieve full source file path using JavaParser or compiler output (inputFiles.lst)
+    private static Path getSourceFile(Collection<File> javaSourceFiles, String className) {
         final String relativeFilePath = className.replace('.','/') + ".java";
-        return className.replace('.','/') + ".java";
+        final Optional<Path> sourceFile = javaSourceFiles.stream().map(File::toPath).filter(p -> p.endsWith(relativeFilePath)).findFirst();
+        return sourceFile.orElse(null);
     }
 }

--- a/jtec-core/src/main/java/edu/tum/sse/jtec/util/LCOVUtils.java
+++ b/jtec-core/src/main/java/edu/tum/sse/jtec/util/LCOVUtils.java
@@ -1,0 +1,37 @@
+package edu.tum.sse.jtec.util;
+
+import edu.tum.sse.jtec.reporting.TestReport;
+import edu.tum.sse.jtec.reporting.TestSuite;
+
+import java.util.Set;
+
+public class LCOVUtils {
+    public static String toLcov(TestReport testReport)  {
+        StringBuilder lcovTestReport = new StringBuilder();
+        for (TestSuite testSuite : testReport.getTestSuites()) {
+            final Set<String> coveredEntities = testSuite.getCoveredEntities();
+            // TODO: TN at the start of every entity's section?
+            lcovTestReport.append("TN:").append(testSuite.getTestId()).append('\n');
+
+            // TODO: filter for entities in project
+            for (String entity : coveredEntities) {
+                // TODO: find associated source file
+                String sourceFilePath = getSourceFilePath(entity);
+
+                // TODO: get covered lines (use entire class/method)
+
+                // TODO: Append section to lcov report
+                lcovTestReport.append("SF:").append(sourceFilePath).append('\n');
+                // TODO: Add covered line data (DA, LF, LH)
+                lcovTestReport.append("end_of_record\n");
+            }
+        }
+        return lcovTestReport.toString();
+    }
+
+    private static String getSourceFilePath(String className) {
+        // TODO Retrieve full source file path using JavaParser or compiler output (inputFiles.lst)
+        final String relativeFilePath = className.replace('.','/') + ".java";
+        return className.replace('.','/') + ".java";
+    }
+}

--- a/jtec-core/src/test/java/edu/tum/sse/jtec/reporting/LCOVReportParserTest.java
+++ b/jtec-core/src/test/java/edu/tum/sse/jtec/reporting/LCOVReportParserTest.java
@@ -1,0 +1,48 @@
+package edu.tum.sse.jtec.reporting;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+class LCOVReportParserTest {
+
+    @Test
+    void shouldParseTestReportIntoLcovReport() throws URISyntaxException, IOException {
+        // given
+        final Path baseDirectory = Paths.get(this.getClass().getResource("/sample-classes").toURI()).toAbsolutePath();
+
+        TestSuite testSuite = new TestSuite();
+        Set<String> coveredEntities = new HashSet<>(Arrays.asList(
+                "com.example.SomeClass",
+                "com.example.AnotherClass#<init>()void",
+                "com.example.AnotherClass#printBaz()void"));
+        testSuite.setCoveredEntities(coveredEntities);
+        TestReport testReport = new TestReport("report", 1L, 1L, Collections.singletonList(testSuite));
+        LCOVReportParser parser = new LCOVReportParser(baseDirectory);
+
+        // when
+        LCOVReport lcovReport = parser.parse(testReport);
+        List<LCOVSection> lcovSections = lcovReport.getLcovSections();
+
+        // then
+        assertEquals(2, lcovSections.size());
+        Optional<LCOVSection> lcovSection1 = lcovSections.stream().filter(s -> s.getSourceFilePath().contains("SomeClass")).findFirst();
+        Optional<LCOVSection> lcovSection2 = lcovSections.stream().filter(s -> s.getSourceFilePath().contains("AnotherClass")).findFirst();
+        assertTrue(lcovSection1.isPresent());
+        assertTrue(lcovSection2.isPresent());
+        assertEquals(6, lcovSection1.get().numLinesFound());
+        assertEquals(6, lcovSection1.get().numLinesHit());
+        assertEquals(2, lcovSection1.get().numMethodsFound());
+        assertEquals(2, lcovSection1.get().numMethodsHit());
+        assertEquals(9, lcovSection2.get().numLinesFound());
+        assertEquals(6, lcovSection2.get().numLinesHit());
+        assertEquals(3, lcovSection2.get().numMethodsFound());
+        assertEquals(2, lcovSection2.get().numMethodsHit());
+    }
+}

--- a/jtec-core/src/test/java/edu/tum/sse/jtec/reporting/LCOVReportTest.java
+++ b/jtec-core/src/test/java/edu/tum/sse/jtec/reporting/LCOVReportTest.java
@@ -1,0 +1,33 @@
+package edu.tum.sse.jtec.reporting;
+
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LCOVReportTest {
+
+    @Test
+    void shouldGetLcovSection() {
+        // given
+        String sourceFilePath = "path/to/file_1";
+        LCOVSection lcovSection = new LCOVSection("test-1", sourceFilePath);
+        List<LCOVSection> lcovSections = Arrays.asList(
+                new LCOVSection("test-1", "path/to/file_2"),
+                lcovSection
+        );
+        LCOVReport lcovReport = new LCOVReport(lcovSections);
+
+        // when
+        Optional<LCOVSection> actualLcovSection = lcovReport.getLcovSection(sourceFilePath);
+
+        // then
+        assertTrue(actualLcovSection.isPresent());
+        assertEquals(actualLcovSection.get(), lcovSection);
+    }
+}

--- a/jtec-core/src/test/java/edu/tum/sse/jtec/reporting/LCOVSectionTest.java
+++ b/jtec-core/src/test/java/edu/tum/sse/jtec/reporting/LCOVSectionTest.java
@@ -1,0 +1,35 @@
+package edu.tum.sse.jtec.reporting;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LCOVSectionTest {
+    @Test
+    void shouldConvertToLcovFormattedString() {
+        // given
+        LCOVSection lcovSection = new LCOVSection("test-suite", "path/to/source_file");
+        lcovSection.addMethod(5 ,"foo");
+        lcovSection.addMethodHit(1, "foo");
+        lcovSection.addLineHit(5, 1);
+        lcovSection.addLineHit(6, 1);
+        lcovSection.addLineHit(7, 1);
+
+        // when
+        String lcovString = lcovSection.toString();
+
+        // then
+        assertEquals("TN:test-suite\n" +
+                "SF:path/to/source_file\n" +
+                "FN:5,foo\n" +
+                "FNDA:1,foo\n" +
+                "FNF:1\n" +
+                "FNH:1\n" +
+                "DA:5,1\n" +
+                "DA:6,1\n" +
+                "DA:7,1\n" +
+                "LF:3\n" +
+                "LH:3\n" +
+                "end_of_record\n", lcovString);
+    }
+}

--- a/jtec-core/src/test/resources/sample-classes/AnotherClass.java
+++ b/jtec-core/src/test/resources/sample-classes/AnotherClass.java
@@ -1,0 +1,17 @@
+package com.example;
+
+public class AnotherClass {
+    private int bar;
+
+    public AnotherClass(int bar) {
+        this.bar = bar;
+    }
+
+    public int getBar() {
+        return bar;
+    }
+
+    public static int printBaz() {
+        System.out.println("baz");
+    }
+}

--- a/jtec-core/src/test/resources/sample-classes/SomeClass.java
+++ b/jtec-core/src/test/resources/sample-classes/SomeClass.java
@@ -1,0 +1,13 @@
+package com.example;
+
+public class SomeClass {
+    private int foo;
+
+    public SomeClass(int foo) {
+        this.foo = foo;
+    }
+
+    public int getFoo() {
+        return foo;
+    }
+}

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/AbstractJTeCReportMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/AbstractJTeCReportMojo.java
@@ -2,7 +2,6 @@ package edu.tum.sse.jtec.mojo;
 
 import edu.tum.sse.jtec.reporting.TestReport;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -21,7 +20,7 @@ public abstract class AbstractJTeCReportMojo extends AbstractJTeCMojo {
     boolean storeTestReport(TestReport testReport) throws IOException {
         Path jsonFile = outputDirectory.toPath().resolve(TEST_REPORT_JSON_FILENAME);
         Path lcovFile = outputDirectory.toPath().resolve(TEST_REPORT_LCOV_FILENAME);
-        File baseDir = project.getBasedir();
+        Path baseDirectory = project.getBasedir().toPath();
         Files.deleteIfExists(jsonFile);
         Files.deleteIfExists(lcovFile);
         if (testReport.getTestSuites().size() == 0) {
@@ -31,7 +30,7 @@ public abstract class AbstractJTeCReportMojo extends AbstractJTeCMojo {
         final String jsonTestReport = toJson(testReport);
         createFileAndEnclosingDir(jsonFile);
         writeToFile(jsonFile, jsonTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);
-        final String lcovTestReport = toLcov(testReport, baseDir);
+        final String lcovTestReport = toLcov(testReport, baseDirectory);
         createFileAndEnclosingDir(lcovFile);
         writeToFile(lcovFile, lcovTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);
         return true;

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/AbstractJTeCReportMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/AbstractJTeCReportMojo.java
@@ -10,14 +10,18 @@ import java.nio.file.StandardOpenOption;
 import static edu.tum.sse.jtec.util.IOUtils.createFileAndEnclosingDir;
 import static edu.tum.sse.jtec.util.IOUtils.writeToFile;
 import static edu.tum.sse.jtec.util.JSONUtils.toJson;
+import static edu.tum.sse.jtec.util.LCOVUtils.toLcov;
 
 public abstract class AbstractJTeCReportMojo extends AbstractJTeCMojo {
 
-    final static String TEST_REPORT_FILENAME = "test-report.json";
+    final static String TEST_REPORT_JSON_FILENAME = "test-report.json";
+    final static String TEST_REPORT_LCOV_FILENAME = "test-report.info";
 
     boolean storeTestReport(TestReport testReport) throws IOException {
-        Path jsonFile = outputDirectory.toPath().resolve(TEST_REPORT_FILENAME);
+        Path jsonFile = outputDirectory.toPath().resolve(TEST_REPORT_JSON_FILENAME);
+        Path lcovFile = outputDirectory.toPath().resolve(TEST_REPORT_LCOV_FILENAME);
         Files.deleteIfExists(jsonFile);
+        Files.deleteIfExists(lcovFile);
         if (testReport.getTestSuites().size() == 0) {
             getLog().warn("No Test Suites found during report generation.");
             return false;
@@ -25,6 +29,9 @@ public abstract class AbstractJTeCReportMojo extends AbstractJTeCMojo {
         final String jsonTestReport = toJson(testReport);
         createFileAndEnclosingDir(jsonFile);
         writeToFile(jsonFile, jsonTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);
+        final String lcovTestReport = toLcov(testReport);
+        createFileAndEnclosingDir(lcovFile);
+        writeToFile(lcovFile, lcovTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);
         return true;
     }
 }

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/AbstractJTeCReportMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/AbstractJTeCReportMojo.java
@@ -26,10 +26,8 @@ public abstract class AbstractJTeCReportMojo extends AbstractJTeCMojo {
 
     boolean storeTestReport(TestReport testReport) throws IOException {
         Path jsonFile = outputDirectory.toPath().resolve(TEST_REPORT_JSON_FILENAME);
-        Path lcovFile = outputDirectory.toPath().resolve(TEST_REPORT_LCOV_FILENAME);
         Path baseDirectory = project.getBasedir().toPath();
         Files.deleteIfExists(jsonFile);
-        Files.deleteIfExists(lcovFile);
         if (testReport.getTestSuites().size() == 0) {
             getLog().warn("No Test Suites found during report generation.");
             return false;
@@ -38,6 +36,8 @@ public abstract class AbstractJTeCReportMojo extends AbstractJTeCMojo {
         createFileAndEnclosingDir(jsonFile);
         writeToFile(jsonFile, jsonTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);
         if (lcovEnabled) {
+            Path lcovFile = outputDirectory.toPath().resolve(TEST_REPORT_LCOV_FILENAME);
+            Files.deleteIfExists(lcovFile);
             final String lcovTestReport = toLcov(testReport, baseDirectory);
             createFileAndEnclosingDir(lcovFile);
             writeToFile(lcovFile, lcovTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/AbstractJTeCReportMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/AbstractJTeCReportMojo.java
@@ -2,6 +2,7 @@ package edu.tum.sse.jtec.mojo;
 
 import edu.tum.sse.jtec.reporting.TestReport;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,6 +21,7 @@ public abstract class AbstractJTeCReportMojo extends AbstractJTeCMojo {
     boolean storeTestReport(TestReport testReport) throws IOException {
         Path jsonFile = outputDirectory.toPath().resolve(TEST_REPORT_JSON_FILENAME);
         Path lcovFile = outputDirectory.toPath().resolve(TEST_REPORT_LCOV_FILENAME);
+        File baseDir = project.getBasedir();
         Files.deleteIfExists(jsonFile);
         Files.deleteIfExists(lcovFile);
         if (testReport.getTestSuites().size() == 0) {
@@ -29,7 +31,7 @@ public abstract class AbstractJTeCReportMojo extends AbstractJTeCMojo {
         final String jsonTestReport = toJson(testReport);
         createFileAndEnclosingDir(jsonFile);
         writeToFile(jsonFile, jsonTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);
-        final String lcovTestReport = toLcov(testReport);
+        final String lcovTestReport = toLcov(testReport, baseDir);
         createFileAndEnclosingDir(lcovFile);
         writeToFile(lcovFile, lcovTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);
         return true;

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/AbstractJTeCReportMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/AbstractJTeCReportMojo.java
@@ -1,6 +1,7 @@
 package edu.tum.sse.jtec.mojo;
 
 import edu.tum.sse.jtec.reporting.TestReport;
+import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -17,6 +18,12 @@ public abstract class AbstractJTeCReportMojo extends AbstractJTeCMojo {
     final static String TEST_REPORT_JSON_FILENAME = "test-report.json";
     final static String TEST_REPORT_LCOV_FILENAME = "test-report.info";
 
+    /**
+     * JTeC option to enable generating an LCOV file for the test report.
+     */
+    @Parameter(property = "jtec.lcov", readonly = true, defaultValue = "false")
+    boolean lcovEnabled;
+
     boolean storeTestReport(TestReport testReport) throws IOException {
         Path jsonFile = outputDirectory.toPath().resolve(TEST_REPORT_JSON_FILENAME);
         Path lcovFile = outputDirectory.toPath().resolve(TEST_REPORT_LCOV_FILENAME);
@@ -30,9 +37,11 @@ public abstract class AbstractJTeCReportMojo extends AbstractJTeCMojo {
         final String jsonTestReport = toJson(testReport);
         createFileAndEnclosingDir(jsonFile);
         writeToFile(jsonFile, jsonTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);
-        final String lcovTestReport = toLcov(testReport, baseDirectory);
-        createFileAndEnclosingDir(lcovFile);
-        writeToFile(lcovFile, lcovTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);
+        if (lcovEnabled) {
+            final String lcovTestReport = toLcov(testReport, baseDirectory);
+            createFileAndEnclosingDir(lcovFile);
+            writeToFile(lcovFile, lcovTestReport, false, StandardOpenOption.TRUNCATE_EXISTING);
+        }
         return true;
     }
 }

--- a/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCReportAggregateMojo.java
+++ b/jtec-maven-plugin/src/main/java/edu/tum/sse/jtec/mojo/JTeCReportAggregateMojo.java
@@ -27,7 +27,7 @@ public class JTeCReportAggregateMojo extends AbstractJTeCReportMojo {
         try {
             if (session.getCurrentProject().isExecutionRoot()) {
                 List<Path> reportPaths = session.getAllProjects().stream()
-                        .map(mavenProject -> mavenProject.getBasedir().toPath().resolve("target/jtec").resolve(TEST_REPORT_FILENAME))
+                        .map(mavenProject -> mavenProject.getBasedir().toPath().resolve("target/jtec").resolve(TEST_REPORT_JSON_FILENAME))
                         .filter(Files::exists)
                         .collect(Collectors.toList());
                 List<TestReport> testReports = reportPaths.stream()


### PR DESCRIPTION
#57 

A JTeC `TestReport` can be converted into an [LCOV](https://ltp.sourceforge.net/coverage/lcov/geninfo.1.php) file. Both class-level and method-level coverage are supported.

The HTML coverage report can be generated from an existing LCOV file with `genhtml`, e.g.:
`genhtml jtec-sample-project/junit5-project/target/jtec/test-report.info -o lcov_out`

**Open issues:**
- [x] Add constructors to LCOV report (`ConstructorDeclaration`)
- [x] Methods declared inside another method not present in JTeC coverage report, but found by `JavaParser` (e.g., `run` in `ThreadStarter`)
- [x] Find correct source file even if directory structure differs from package name